### PR TITLE
Apply MQTT credentials

### DIFF
--- a/examples/zigbee2mqtt/zigbee2mqtt.ino
+++ b/examples/zigbee2mqtt/zigbee2mqtt.ino
@@ -260,6 +260,7 @@ void onWiFiEvent(WiFiEvent_t event) {
             staStatus = "running";
             Serial.print("Obtained IP address: ");
             Serial.println(WiFi.localIP());
+            mqtt.setUsernamePassword(mqttUsername.c_str(), mqttPassword.c_str());
             mqtt.connect(mqttServer.c_str(), mqttPort);
             break;
         case ARDUINO_EVENT_WIFI_STA_LOST_IP:


### PR DESCRIPTION
Fix MQTT authentication by setting credentials before connecting to the server.